### PR TITLE
minor doc fixes; missing config init

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/vulcanize/eth-ipfs-state-validator)](https://goreportcard.com/report/github.com/vulcanize/eth-ipfs-state-validator)
 
-> Uses [ipfs-ethdb](https://github.com/vulcanize/ipfs-ethdb/postgres) to validate completeness of IPFS Ethereum state data
+> Uses [ipfs-ethdb](https://github.com/vulcanize/ipfs-ethdb/tree/master/postgres) to validate completeness of IPFS Ethereum state data
 
 ## Background
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,9 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -24,14 +26,9 @@ import (
 )
 
 var (
-	subCommand      string
-	logWithCommand  logrus.Entry
-	stateRootStr    string
-	storageRootStr  string
-	validationType  string
-	contractAddrStr string
-	cfgFile         string
-	ipfsPath        string
+	subCommand     string
+	logWithCommand logrus.Entry
+	cfgFile        string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -82,6 +79,8 @@ func logLevel() error {
 }
 
 func init() {
+	cobra.OnInitialize(initConfig)
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file location")
@@ -100,4 +99,17 @@ func init() {
 	viper.BindPFlag("database.user", rootCmd.PersistentFlags().Lookup("database-user"))
 	viper.BindPFlag("database.password", rootCmd.PersistentFlags().Lookup("database-password"))
 	viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log-level"))
+}
+
+func initConfig() {
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+		if err := viper.ReadInConfig(); err == nil {
+			logrus.Printf("Using config file: %s", viper.ConfigFileUsed())
+		} else {
+			logrus.Fatal(fmt.Sprintf("Couldn't read config file: %s", err.Error()))
+		}
+	} else {
+		logrus.Warn("No config file passed with --config flag")
+	}
 }

--- a/environments/example.toml
+++ b/environments/example.toml
@@ -1,6 +1,10 @@
 [database]
-    name     = "vulcanize_public" # $DATABASE_NAME
-    hostname = "localhost" # $DATABASE_HOSTNAME
-    port     = 5432 # $DATABASE_PORT
-    user     = "postgres" # $DATABASE_USER
-    password = "" # $DATABASE_PASSWORD
+    name     = "vulcanize_public"
+    hostname = "localhost"
+    port     = 5432
+    user     = "postgres"
+    password = ""
+
+[validator]
+    type = "state"
+    stateRoot = "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"


### PR DESCRIPTION
Note: This has now been used to validate completeness of state tries extracted by https://github.com/vulcanize/eth-pg-ipfs-state-snapshot

Next step is to validate completeness of state at `m` when we have a snapshot at block `n` and a compete set of state diffs from `n+1` to `m` (diffs from https://github.com/vulcanize/ipfs-blockchain-watcher)