### PR TITLE
fix

### DIFF
--- a/pkg/validator.go
+++ b/pkg/validator.go
@@ -17,8 +17,6 @@
 package validator
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -75,20 +73,11 @@ func NewValidator(kvs ethdb.KeyValueStore, database ethdb.Database) *Validator {
 // This does consider child storage tries
 func (v *Validator) ValidateTrie(stateRoot common.Hash) error {
 	// Generate the state.NodeIterator for this root
-	stateDB, err := state.New(common.Hash{}, v.stateDatabase, nil)
+	stateDB, err := state.New(stateRoot, v.stateDatabase, nil)
 	if err != nil {
 		return err
 	}
 	it := state.NewNodeIterator(stateDB)
-	// state.NodeIterator won't throw an error if we can't find the root node
-	// check if it exists first
-	exists, err := v.kvs.Has(stateRoot.Bytes())
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("root node for hash %s does not exist in database", stateRoot.Hex())
-	}
 	for it.Next() {
 		// iterate through entire state trie and descendent storage tries
 		// it.Next() will return false when we have either completed iteration of the entire trie or have ran into an error (e.g. a missing node)


### PR DESCRIPTION
code referenced by codehash in contract accounts needs to be present in kv dstore for the trie to be considered complete by the state node iterator